### PR TITLE
Bug fixes & clean code fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ CMakeCache.txt
 CMakeFiles/
 *.ii
 *.s
+bin/
+.idea/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,13 +14,4 @@ set(COMMON_FLAGS "-Os")
 
 project(PullTester C CXX)
 
-add_executable(${PROJECT_NAME} ${PROJECT_NAME})
-
-#create_top_project(${PROJECT_NAME})
-
-
-################################################################################
-### Template code. Do not modify                                               #
-                                                                               #
-include(${PROPWARE_PATH}/CMakePropellerFooter.cmake)                           #
-################################################################################
+create_simple_executable(${PROJECT_NAME} ${PROJECT_NAME})

--- a/PullTester.cpp
+++ b/PullTester.cpp
@@ -1,28 +1,32 @@
-#include <stdio.h>
+#include <PropWare/printer/printer.h>
 #include <PropWare/mcp3000.h>
-//#include <simple/simpletools.h>
+
 using namespace PropWare;
 
-int main(){
-	printf("Hello World-Initializing ADC NOW");
-	MCP3000::PartNumber PartNo = MCP3000::MCP320x;
-	PropWare::SPI *spi = PropWare::SPI::get_instance();
-	MCP3000::Channel chan = MCP3000::CHANNEL_0;
-	MCP3000 adc(spi,PartNo);
-	
-	Port::Mask MOSI = Port::P1;
-	Port::Mask MISO = Port::P1;
-	Port::Mask SCLK = Port::P0;
-	Port::Mask CS = Port::P2;
+const Port::Mask SCLK = Port::P0;
+const Port::Mask MISO = Port::P1;
+const Port::Mask MOSI = Port::P2;
+const Port::Mask CS   = Port::P3;
 
-	adc.start(MOSI, MISO, SCLK, CS);
-//	pause(1000);
-	printf("ADC STARTED: \n");
-	uint16_t data = -1;
-	for(int i =0;i<100;i++){
-		adc.read(chan, &data);
-		printf("The ADC value is %d \n", data); 
-//		pause(100);
-		waitcnt(CLKFREQ+CNT);
+const MCP3000::Channel    CHAN    = MCP3000::CHANNEL_0;
+const MCP3000::PartNumber PART_NO = MCP3000::MCP320x;
+
+int main () {
+	ErrorCode errorCode;
+	uint16_t  data;
+
+	pwOut.printf("Hello World-Initializing ADC NOW");
+	SPI     *spi = SPI::get_instance();
+	MCP3000 adc(spi, PART_NO);
+
+	errorCode = adc.start(MOSI, MISO, SCLK, CS);
+	pwOut.printf("ADC STARTED: (code = %d)" CRLF, errorCode);
+
+	for (int i = 0; i < 100; i++) {
+		errorCode = adc.read(CHAN, &data);
+		pwOut.printf("The ADC value is %d (code = %d)" CRLF, data, errorCode);
+		waitcnt(SECOND + CNT);
 	}
+
+	return 0;
 }


### PR DESCRIPTION
- constants moved to global scope and set as const
- Use pwOut.printf instead of printf
  - Along with printf -> pwOut.printf means using the CRLF macro instead of `\n`
- use PropWare's `SECOND` macro instead of `CLKFREQ`
- No need to initialize the data variable since it will be written to before being read from
- Add error display to ensure life is good
- Ignore CLion & CMake files
- Update CMake file to latest version of PropWare
